### PR TITLE
support a MUD_PASSWORD environment variable

### DIFF
--- a/Get-CharInfo.ps1
+++ b/Get-CharInfo.ps1
@@ -1,7 +1,13 @@
 $ApiUrl  = 'https://kallisti.nonserviam.net/api/v1'
 
 $USERNAME = Read-Host "Username"
-$PWD_SECURE = Read-Host "Password" -AsSecureString
+
+if ($null -eq $env:MUD_PASSWORD) {
+  $PWD_SECURE = Read-Host "Password" -AsSecureString
+} else {
+  $PWD_SECURE = ConvertTo-SecureString "$([Environment]::GetEnvironmentVariable('MUD_PASSWORD'))" -AsPlainText -Force
+}
+
 $TokenUrl = "$ApiUrl/auth/token/login"
 $AuthParams = @{
     "email"=$USERNAME


### PR DESCRIPTION
if you have your mud password in MUD_PASSWORD environment variable, script will now use that and not ask you to enter it.